### PR TITLE
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/main.rs:116:37

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ I'm sure there are bugs included as well.
 asar_extract FILE [DEST_DIR]
 ```
 If no *DEST_DIR* is provided it will extract it into the current directory.
+


### PR DESCRIPTION
This is more of an issue than a PR. I would have opened an issue but I can't seem to find the button for that.

Thank you for writing this program! I want to use your asar_extract on a bunch of computers to extract an electron app and recompile it. Unfortunately asar_extract failed partway through extraction. Error in title.

I'm fairly confident that this is due to some files being included "in" the asar archive, but not actually present inside of the file. I noticed that when using the official `asar` command, the app.asar had to reside alongside a folder called `app.asar.unpacked`, otherwise `asar` would complain of missing files.

I'm not sure if you still maintain this project, Lem, but I am just one person out there who finds it useful and who would love to use it if you fix this one thing.

Below, I've attached a zip file containing the .asar file alongside the `app.asar.unpacked` folder. Hopefully you can reproduce my error and issue a fix. This should be pretty easy.
[resources.zip](https://github.com/Lem/asar_extract/files/10418990/resources.zip)
